### PR TITLE
fix(docs): adjust api route documentation examples

### DIFF
--- a/docs/03-pages/01-building-your-application/01-routing/07-api-routes.mdx
+++ b/docs/03-pages/01-building-your-application/01-routing/07-api-routes.mdx
@@ -217,7 +217,7 @@ The following example sends a JSON response with the status code `200` (`OK`) an
 ```ts filename="pages/api/hello.ts" switcher
 import type { NextApiRequest, NextApiResponse } from 'next'
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     const result = await someAsyncOperation()
     res.status(200).json({ result })
@@ -228,7 +228,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 ```
 
 ```js filename="pages/api/hello.js" switcher
-export default function handler(req, res) {
+export default async function handler(req, res) {
   try {
     const result = await someAsyncOperation()
     res.status(200).json({ result })
@@ -247,7 +247,7 @@ The following example sends a HTTP response with the status code `200` (`OK`) an
 ```ts filename="pages/api/hello.ts" switcher
 import type { NextApiRequest, NextApiResponse } from 'next'
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     const result = await someAsyncOperation()
     res.status(200).send({ result })
@@ -258,7 +258,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 ```
 
 ```js filename="pages/api/hello.js" switcher
-export default function handler(req, res) {
+export default async function handler(req, res) {
   try {
     const result = await someAsyncOperation()
     res.status(200).send({ result })
@@ -277,7 +277,7 @@ The following example redirects the client to the `/` path if the form is succes
 ```ts filename="pages/api/hello.ts" switcher
 import type { NextApiRequest, NextApiResponse } from 'next'
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { name, message } = req.body
 
   try {
@@ -290,7 +290,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 ```
 
 ```js filename="pages/api/hello.js" switcher
-export default function handler(req, res) {
+export default async function handler(req, res) {
   const { name, message } = req.body
 
   try {


### PR DESCRIPTION
Fixed the example functions in the documentation to use `async` in order to use `await` within the function body. 